### PR TITLE
Link to correct repository and bump version to republish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "tessel-soil-moisture-sensor",
-  "version": "0.0.1",
-  "description": "Tessel project",
+  "version": "0.0.2",
+  "description": "Soil moisture sensor for Tessel",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "www.github.com/tessel/t2-cli"
+    "url": "https://github.com/sarmadsangi/tessel-soil-moisture-sensor"
   },
   "keywords": [
     "Tessel"


### PR DESCRIPTION
Came across this:

![screen shot 2016-12-03 at 10 30 13 am](https://cloud.githubusercontent.com/assets/454690/20861376/7ff89a4e-b943-11e6-9f52-3c9630334564.png)

on https://libraries.io/npm/tessel-soil-moisture-sensor

Probably best if it links to the right repo ;)